### PR TITLE
[OPS-6030] Allow configuration of PDF header and footer.

### DIFF
--- a/ocha_snap.admin.inc
+++ b/ocha_snap.admin.inc
@@ -10,8 +10,9 @@
 function ocha_snap_settings() {
 
   $form['ocha_snap_tokens'] = array(
-    '#type' => 'markup',
-    '#value' => t('You can use the token [pagination] in both the header and footer. It will be replaced with a translated version of the text <em>Page current of total</em> with the appropriate numbers inserted.'),
+    '#type'   => 'item',
+    '#title'  => t('Tokens'),
+    '#markup' => t('You can use the token <em>[pagination]</em> in both the header and footer. It will be replaced with a translated version of the text <em>Page current of total</em> with the appropriate numbers inserted.'),
   );
 
   $form['ocha_snap_header'] = array(

--- a/ocha_snap.admin.inc
+++ b/ocha_snap.admin.inc
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @file
+ * Administration functions for the snap module.
+ */
+
+/**
+ * Admin settings form callback.
+ */
+function ocha_snap_settings() {
+
+  $form['ocha_snap_tokens'] = array(
+    '#type' => 'markup',
+    '#value' => t('You can use the token [pagination] in both the header and footer. It will be replaced with a translated version of the text <em>Page current of total</em> with the appropriate numbers inserted.'),
+  );
+
+  $form['ocha_snap_header'] = array(
+    '#type'          => 'textarea',
+    '#title'         => t('PDF Header'),
+    '#description'   => t('HTML content to use as the generated PDF header. You can <em>not</em> use remote references for images or stylesheets. Any javascript is ignored.'),
+    '#default_value' => variable_get('ocha_snap_header', ''),
+  );
+
+  $form['ocha_snap_footer'] = array(
+    '#type'          => 'textarea',
+    '#title'         => t('PDF Footer'),
+    '#description'   => t('HTML content to use as the generated PDF footer. You can <em>not</em> use remote references for images or stylesheets. Any javascript is ignored.'),
+    '#default_value' => variable_get('ocha_snap_footer', ''),
+  );
+
+  $form['ocha_snap_css'] = array(
+    '#type'          => 'textarea',
+    '#title'         => t('PDF CSS'),
+    '#description'   => t('Any custom CSS rules you need injected into the page before the PDF is generated.'),
+    '#default_value' => variable_get('ocha_snap_css', ''),
+  );
+
+  return system_settings_form($form);
+}

--- a/ocha_snap.install
+++ b/ocha_snap.install
@@ -11,4 +11,7 @@ function ocha_snap_uninstall() {
   variable_del('ocha_snap_url');
   variable_del('ocha_snap_site_user');
   variable_del('ocha_snap_site_pass');
+  variable_del('ocha_snap_header');
+  variable_del('ocha_snap_footer');
+  variable_del('ocha_snap_css');
 }

--- a/ocha_snap.module
+++ b/ocha_snap.module
@@ -185,3 +185,10 @@ function ocha_snap_pdf_footer() {
   }
 </style>';
 }
+
+/**
+ * Implements hook_print_pdf_available_libs_alter().
+ */
+function ocha_snap_print_pdf_available_libs_alter(&$pdf_tools) {
+  $pdf_tools['ocha_snap|' . check_plain(variable_get('ocha_snap_url'))] = t('OCHA Snap Service (@url)', array('@url' => variable_get('ocha_snap_url')));
+}

--- a/ocha_snap.module
+++ b/ocha_snap.module
@@ -14,6 +14,22 @@
 define('OCHA_SNAP_URL', 'http://localhost:8442/snap');
 
 /**
+ * Implements hook_menu().
+ */
+function ocha_snap_menu() {
+  $items['admin/config/services/snap'] = array(
+    'title' => 'Snap Service',
+    'description' => 'Snap Service intergration configuration',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ocha_snap_settings'),
+    'access arguments' => array('administer site configuration'),
+    'file' => 'ocha_snap.admin.inc',
+    'type' => MENU_NORMAL_ITEM,
+  );
+  return $items;
+}
+
+/**
  * Helper to fetch the snap service endpoint.
  */
 function ocha_snap_url() {
@@ -57,42 +73,12 @@ function ocha_snap($url, $params = array()) {
   $pdf_pagination = str_replace('[page]', '<span class="pageNumber"></span>', $pdf_pagination);
   $pdf_pagination = str_replace('[topage]', '<span class="totalPages"></span>', $pdf_pagination);
 
-  // Construct our PDF footer.
+  // Construct our PDF header and footer.
   //
   // Note: you CANNOT use remote references such as image URLs or stylesheets,
   // nor can JS be executed in this context. Inline HTML/CSS only!
-  $pdf_footer = <<<PDF_FOOTER
-<footer class="pdf-footer">
-  <div class="pdf-footer__left">
-    $pdf_pagination
-  </div>
-</footer>
-<style type="text/css">
-  *, *:before, *:after {
-    box-sizing: border-box;
-    -webkit-print-color-adjust: exact;
-  }
-  .pdf-footer {
-    display: table;
-    width: 100%;
-    margin: 0 5mm;
-    white-space: nowrap;
-
-    font-family: Roboto, serif;
-    font-weight: 400;
-    font-size: 9px;
-  }
-  .pdf-footer__left,
-  .pdf-footer__right {
-    display: table-cell;
-    vertical-align: bottom;
-    width: 49%;
-  }
-  .pdf-footer__right {
-    text-align: right;
-  }
-</style>
-PDF_FOOTER;
+  $pdf_header = str_replace('[pagination]', $pdf_pagination, ocha_snap_pdf_header());
+  $pdf_footer = str_replace('[pagination]', $pdf_pagination, ocha_snap_pdf_footer());
 
   $default_params = array(
     'url'           => $url,
@@ -103,7 +89,7 @@ PDF_FOOTER;
     'pdfLandscape'  => 'false',
     'pdfBackground' => 'true',
     // Suppress default header by sending space character.
-    'pdfHeader'     => ' ',
+    'pdfHeader'     => $pdf_header,
     'pdfFooter'     => $pdf_footer,
     'pdfMarginTop'  => '24',
     'pdfMarginUnit' => 'px',
@@ -145,4 +131,57 @@ PDF_FOOTER;
   }
 
   return $output->data;
+}
+
+/**
+ * Generate a PDF header snippet.
+ */
+function ocha_snap_pdf_header() {
+  // The default is a single space which suppresses header output.
+  $header = variable_get('ocha_snap_header', ' ');
+
+  // If CSS is specified, now would be a good time to inject it.
+  if ($css = variable_get('ocha_snap_css', '')) {
+    $header .= '<style type="text/css">' . $css . '</style>';
+  }
+  return $header;
+}
+
+/**
+ * Provide a default PDF footer for compatibility reasons.
+ */
+function ocha_snap_pdf_footer() {
+  if ($footer = variable_get('ocha_snap_footer', '')) {
+    return $footer;
+  }
+  return '<footer class="pdf-footer">
+  <div class="pdf-footer__left">
+    [pagination]
+  </div>
+</footer>
+<style type="text/css">
+  *, *:before, *:after {
+    box-sizing: border-box;
+    -webkit-print-color-adjust: exact;
+  }
+  .pdf-footer {
+    display: table;
+    width: 100%;
+    margin: 0 5mm;
+    white-space: nowrap;
+
+    font-family: Roboto, serif;
+    font-weight: 400;
+    font-size: 9px;
+  }
+  .pdf-footer__left,
+  .pdf-footer__right {
+    display: table-cell;
+    vertical-align: bottom;
+    width: 49%;
+  }
+  .pdf-footer__right {
+    text-align: right;
+  }
+</style>';
 }


### PR DESCRIPTION
This is deployed to the GMS Sandbox environment. It doesn't seem to apply the CSS, but then again that was broken beforehand and I have no idea if the CSS I added from the allegedly used on-disk file even does what it's supposed to.

What *does* work is the admin, the Print_PDF module integration (which really is just cosmetic) and the passing of the configured header/footer to the service via the appropriate params, as I see them getting logged.

So, you lose some, you win some. Overall seems to not break more things than it fixes and allowed me to remove ~150MB of cruft from the GMS site repo.