### PR TITLE
chore: allow exceptions to be handled later on

### DIFF
--- a/ocha_snap.module
+++ b/ocha_snap.module
@@ -112,6 +112,7 @@ function ocha_snap_generate($url, array $params = []) {
     'headers' => [
       'X-Forwarded-For' => Drupal::request()->getClientIp(),
       'User-Agent'      => $_SERVER['HTTP_USER_AGENT'],
+      'http_errors'     => FALSE,
     ],
     'method' => 'POST',
   ];


### PR DESCRIPTION
Refs: OPS-9238

https://github.com/UN-OCHA/ocha_snap/pull/14 didn't fix all the errors - trying locally suggests that suppressing the server exceptions allows us to handle them better in the calling module. Otherwise, guzzle gives a 500 directly and we don't get to handle it.

https://docs.guzzlephp.org/en/latest/request-options.html#http-errors