### PR TITLE
chore: relax restrictions on version of composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-only",
     "require": {
-        "composer/installers": "^1.2",
+        "composer/installers": "^1 || ^2",
         "drupal/core": "^8 || ^9 || ^10"
     },
     "require-dev": {


### PR DESCRIPTION
Refs: updates

Followed a dependency chain from `drupal/recommended-project` - I haven't tested this, but assume we're okay to allow v2 here.