### PR TITLE
chore: avoid deprecation warning

### DIFF
--- a/ocha_snap.module
+++ b/ocha_snap.module
@@ -149,7 +149,7 @@ function ocha_snap_generate($url, array $params = []) {
  */
 function ocha_snap_pdf_header() {
   // The default is a single space which suppresses header output.
-  $header = \Drupal::config('ocha_snap.settings')->get('header');
+  $header = \Drupal::config('ocha_snap.settings')->get('header') ?? '';
 
   // If CSS is specified, now would be a good time to inject it.
   if ($css = \Drupal::config('ocha_snap.settings')->get('css')) {


### PR DESCRIPTION
Refs: OPS-10849

Addresses `Deprecated function: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in ocha_snap_generate() (line 66 of modules/contrib/ocha_snap/ocha_snap.module).`

`config->get()` returns `NULL` if there isn't anything set: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Config%21Config.php/function/Config%3A%3Aget/10